### PR TITLE
Adds node_prereqs_installation to requirements task

### DIFF
--- a/funcmd/cmd.py
+++ b/funcmd/cmd.py
@@ -111,11 +111,15 @@ def install_prerequirements():
         "../fun-apps/requirements/dev.txt",
     ]
 
+    # Install python requirements
     def install_edx_and_fun_requirements():
         from paver.easy import sh
         for req_file in PYTHON_REQ_FILES:
             sh("pip install -q --exists-action w -r {req_file}".format(req_file=req_file))
     pavelib.prereqs.prereq_cache("Python prereqs", PYTHON_REQ_FILES, install_edx_and_fun_requirements)
+
+    # Update npm requirements
+    pavelib.prereqs.node_prereqs_installation()
 
 def setup_environment(settings, service):
     """Setup the sys.path and the environment variables required for the given service."""


### PR DESCRIPTION
When upgrading from fun-4.0.2 to fun-4.9.4, I noticed that the npm requirements had changed, but were't upgraded as part of the re-provisioning step.

This PR adds a `node_prereqs_installation` step to the `requirements` command.

**Testing instructions**

To test this PR, you'll need an existing FUN box.

1. Shell into the vagrant guest instance to install this branch:
    ```bash
    sudo su edxapp
    cd ~/fun-cmd
    git add remote opencraft https://github.com/open-craft/fun-cmd
    git fetch opencraft
    git checkout jill/requirements-install-npm
    pip install -e .
    ```
1. In your `fun-apps/releases/Vagrantfile`, modify the `ansible` block to enable verbose output:
   ```diff
    diff --git a/releases/Vagrantfile b/releases/Vagrantfile
    index 3e3dd86..1742137 100644
    --- a/releases/Vagrantfile
    +++ b/releases/Vagrantfile
    @@ -81,5 +84,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           openedx_fun_release: openedx_fun_release,
           checkout_repos: (ENV["VAGRANT_MOUNT_BASE"] == nil),
        }
   +    ansible.verbose = 'v'
      end
   end
   ```
1. From the releases dir, run `FUN_RELEASE=4.9.4 OPENEDX_FUN_RELEASE=4.9.4 vagrant provision` to upgrade an existing VM.
1. Note that in the "changed" output for the "Update requirements" task, information about npm is printed, and the task runs successfully.

**Reviewers**

- [x] @itsjeyd

CC @julAtWork 